### PR TITLE
Add Streamlit case search app using MongoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,79 @@
-# serach_like_gpt
+# Legal Research Copilot
+
+A Streamlit application that lets you search Supreme Court of India decisions stored in MongoDB using a conversational interface similar to ChatGPT.
+
+## Features
+
+- 💬 **Chat-style search** – ask questions in natural language using the Streamlit chat input.
+- 🔎 **MongoDB powered** – retrieves matching cases via MongoDB text search (with a regex fallback when no text index exists).
+- 🧠 **Rich case cards** – displays summaries, issues, reasoning, and outcomes in expandable sections.
+- 🆘 **Offline sample data** – shows curated sample results when MongoDB is unreachable so you can preview the UI immediately.
+
+## Getting started
+
+1. Create and activate a virtual environment (optional but recommended).
+2. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. Set MongoDB connection details (defaults shown):
+
+   ```bash
+   export MONGODB_URI="mongodb://localhost:27017"
+   export MONGODB_DB="law"
+   export MONGODB_COLLECTION="cases"
+   ```
+
+4. Ensure your MongoDB collection has either a [text index](https://www.mongodb.com/docs/manual/core/index-text/) on key fields or contains documents similar to the sample schema provided in `sample_data.py`.
+
+5. Start the Streamlit app:
+
+   ```bash
+   streamlit run app.py
+   ```
+
+6. Open the URL shown in your terminal (usually <http://localhost:8501>) and start chatting with the legal research copilot.
+
+## MongoDB schema expectations
+
+The app assumes each MongoDB document follows the structure illustrated below:
+
+```json
+{
+  "case_title": "In Re: … vs Director General (Prisons)",
+  "court": "SUPREME COURT OF INDIA",
+  "judgment_date": "2023-03-24",
+  "citation": "2023 0 CJ(SC) 242",
+  "bench": ["M.R. Shah", "C.T. Ravikumar"],
+  "issues": ["Whether the non-disclosure …"],
+  "reasoning": {
+    "rejection_of_high_court_methodology": "…"
+  },
+  "outcome": {
+    "decision": "The appeals were allowed …",
+    "directions": ["Set aside …"]
+  },
+  "search_metadata": {
+    "summary": "The Supreme Court allowed …"
+  }
+}
+```
+
+Additional keys are preserved and made available through expanders if desired.
+
+## Configuration tips
+
+- **Text search:** Create a text index covering `case_title`, `issues`, and `search_metadata.summary` to get the best ranking results.
+- **Connection errors:** When the app cannot reach MongoDB it will show a helpful error message and fall back to the bundled sample case data.
+- **Deployment:** Streamlit apps can be deployed on Streamlit Community Cloud, Hugging Face Spaces, or any environment that supports Python + MongoDB networking.
+
+## Development
+
+- Formatters/linters are not enforced, but keeping imports sorted and functions small makes maintenance easier.
+- Run `python -m compileall .` to perform a quick syntax check before committing changes.
+
+## License
+
+This project is provided as-is for demonstration purposes.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,124 @@
+"""Streamlit app that searches legal cases stored in MongoDB."""
+from __future__ import annotations
+
+import os
+import textwrap
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+import streamlit as st
+
+from db import MongoCaseRepository, RepositoryError
+from sample_data import SAMPLE_CASES
+
+
+def _format_date(value: Optional[str]) -> str:
+    """Return a human readable date string."""
+    if not value:
+        return "Unknown"
+    try:
+        return datetime.fromisoformat(value).strftime("%d %b %Y")
+    except ValueError:
+        return value
+
+
+def _render_case(case: Dict[str, Any]) -> None:
+    """Render a single case card."""
+    title = case.get("case_title", "Untitled case")
+    subtitle = f"{case.get('court', 'Unknown court')} · {_format_date(case.get('judgment_date'))}"
+
+    with st.chat_message("assistant"):
+        st.markdown(f"**{title}**  \\n{subtitle}")
+
+        if citation := case.get("citation"):
+            st.caption(citation)
+
+        if summary := case.get("search_metadata", {}).get("summary"):
+            st.write(summary)
+
+        if issues := case.get("issues"):
+            with st.expander("Key Issues", expanded=False):
+                for issue in issues:
+                    st.markdown(f"- {issue}")
+
+        if reasoning := case.get("reasoning"):
+            with st.expander("Reasoning", expanded=False):
+                for key, value in reasoning.items():
+                    title = key.replace("_", " ").title()
+                    st.markdown(f"**{title}**\n\n{textwrap.fill(value, 100)}")
+
+        if outcome := case.get("outcome"):
+            with st.expander("Outcome", expanded=False):
+                if decision := outcome.get("decision"):
+                    st.markdown(f"**Decision**: {decision}")
+                if directions := outcome.get("directions"):
+                    st.markdown("**Directions**:")
+                    for direction in directions:
+                        st.markdown(f"- {direction}")
+
+        if bench := case.get("bench"):
+            st.caption("Bench: " + ", ".join(bench))
+
+
+def _render_user_message(query: str) -> None:
+    with st.chat_message("user"):
+        st.write(query)
+
+
+def _load_repository() -> MongoCaseRepository:
+    mongo_uri = os.environ.get("MONGODB_URI", "mongodb://localhost:27017")
+    database = os.environ.get("MONGODB_DB", "law")
+    collection = os.environ.get("MONGODB_COLLECTION", "cases")
+    return MongoCaseRepository(uri=mongo_uri, database=database, collection=collection)
+
+
+def _search_cases(repository: MongoCaseRepository, query: str) -> List[Dict[str, Any]]:
+    try:
+        return repository.search_cases(query)
+    except RepositoryError as exc:  # pragma: no cover - defensive programming
+        st.error(str(exc))
+        return []
+
+
+def main() -> None:
+    st.set_page_config(page_title="Legal Research Copilot", page_icon="⚖️", layout="wide")
+    st.title("Legal Research Copilot")
+    st.caption("Search Supreme Court judgments like you chat with GPT.")
+
+    repository = _load_repository()
+
+    if "history" not in st.session_state:
+        st.session_state.history = []
+
+    query = st.chat_input("Ask about a case, citation, issue, or judge")
+
+    if query:
+        _render_user_message(query)
+        results = _search_cases(repository, query)
+        if not results:
+            with st.chat_message("assistant"):
+                st.write("No results from MongoDB. Showing sample cases instead.")
+            for case in SAMPLE_CASES:
+                _render_case(case)
+        else:
+            for case in results:
+                _render_case(case)
+        st.session_state.history.append({"query": query, "results": results})
+
+    # Display history in sidebar
+    with st.sidebar:
+        st.header("Search configuration")
+        st.write(
+            "Configure MongoDB via environment variables: "
+            "`MONGODB_URI`, `MONGODB_DB`, `MONGODB_COLLECTION`."
+        )
+        st.subheader("Recent queries")
+        if history := st.session_state.get("history"):
+            for entry in history[-5:][::-1]:
+                st.markdown(f"- {entry['query']}")
+        else:
+            st.caption("Your latest searches will appear here.")
+
+
+if __name__ == "__main__":
+    main()

--- a/db.py
+++ b/db.py
@@ -1,0 +1,105 @@
+"""MongoDB repository helpers for the Streamlit app."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from pymongo import MongoClient, errors
+
+
+class RepositoryError(RuntimeError):
+    """Raised when the Mongo repository cannot be accessed."""
+
+
+@dataclass
+class MongoCaseRepository:
+    """Repository that wraps MongoDB access for legal case documents."""
+
+    uri: str
+    database: str
+    collection: str
+    limit: int = 5
+
+    _client: Optional[MongoClient] = None
+    _collection = None
+
+    def _connect(self) -> None:
+        if self._client is not None:
+            return
+
+        try:
+            self._client = MongoClient(self.uri, serverSelectionTimeoutMS=3000)
+            # Trigger server selection to fail fast when the DB is unavailable.
+            self._client.admin.command("ping")
+            self._collection = self._client[self.database][self.collection]
+        except errors.PyMongoError as exc:  # pragma: no cover - depends on runtime
+            raise RepositoryError(
+                "Could not connect to MongoDB. Please check your connection details."
+            ) from exc
+
+    @property
+    def collection_handle(self):
+        if self._collection is None:
+            self._connect()
+        return self._collection
+
+    def search_cases(self, query: str) -> List[Dict[str, Any]]:
+        """Search cases in MongoDB using a text index or regex fallback."""
+        if not query:
+            return []
+
+        collection = self.collection_handle
+
+        try:
+            cursor = collection.find(
+                {"$text": {"$search": query}},
+                {
+                    "score": {"$meta": "textScore"},
+                    "case_title": 1,
+                    "court": 1,
+                    "judgment_date": 1,
+                    "citation": 1,
+                    "bench": 1,
+                    "issues": 1,
+                    "reasoning": 1,
+                    "outcome": 1,
+                    "search_metadata": 1,
+                },
+                sort=[("score", {"$meta": "textScore"})],
+                limit=self.limit,
+            )
+        except errors.OperationFailure:
+            cursor = collection.find(
+                {
+                    "$or": [
+                        {"case_title": {"$regex": query, "$options": "i"}},
+                        {"issues": {"$regex": query, "$options": "i"}},
+                        {"search_metadata.summary": {"$regex": query, "$options": "i"}},
+                    ]
+                },
+                limit=self.limit,
+            )
+        except errors.PyMongoError as exc:  # pragma: no cover - depends on runtime
+            raise RepositoryError("Failed to run search query against MongoDB.") from exc
+
+        documents: List[Dict[str, Any]] = []
+        for document in cursor:
+            documents.append(self._normalise_document(document))
+
+        return documents
+
+    def _normalise_document(self, document: Dict[str, Any]) -> Dict[str, Any]:
+        if document is None:
+            return {}
+        normalised = dict(document)
+        identifier = normalised.get("_id")
+        if identifier is not None:
+            normalised["_id"] = str(identifier)
+        normalised.pop("score", None)
+        return normalised
+
+    def close(self) -> None:
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+            self._collection = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pymongo>=4.6.0
+streamlit>=1.32.0

--- a/sample_data.py
+++ b/sample_data.py
@@ -1,0 +1,93 @@
+"""Sample case data used when MongoDB is unavailable."""
+from __future__ import annotations
+
+SAMPLE_CASES = [
+    {
+        "_id": "68c93ace241e4ea8580068af",
+        "court": "SUPREME COURT OF INDIA",
+        "FileID": 2368453,
+        "case_title": "In Re: Contagion of Covid-19 Virus in Prisons vs Director General (Prisons)",
+        "citation": "2023 0 CJ(SC) 242",
+        "judgment_date": "2023-03-24",
+        "bench": ["M.R. Shah", "C.T. Ravikumar"],
+        "parties": {
+            "appellant": "In Re: Contagion of Covid-19 Virus in Prisons",
+            "respondent": "Director General (Prisons)",
+        },
+        "case_type": "I A",
+        "case_number": "179931 of 2022 IN SUO MOTO WRIT PETITION (C) NO 01 of 2020",
+        "procedural_history": [
+            {
+                "court": "District Munsif Court",
+                "decision": "Dismissed the Election Petition.",
+            },
+            {
+                "court": "Additional District Judge",
+                "decision": "Allowed the appeal and declared the election void.",
+            },
+            {
+                "court": "High Court of Kerala",
+                "decision": "Dismissed the revision and review petitions, confirming the order of the Additional District Judge.",
+            },
+            {
+                "court": "Supreme Court of India",
+                "decision": "Allowed the appeals, setting aside the lower court orders and dismissing the Election Petition.",
+            },
+        ],
+        "issues": [
+            "Whether the non-disclosure of a past conviction for a minor, regulatory offence under the Kerala Police Act in a nomination form constitutes a 'corrupt practice' of 'undue influence' under the Kerala Panchayat Raj Act, 1994?",
+            "Does such a non-disclosure amount to furnishing 'fake' details under Section 102(1)(ca) of the Kerala Panchayat Raj Act, thereby rendering the election void?",
+            "Whether the legislative intent behind mandatory disclosure of criminal antecedents is limited to serious or heinous offences, or if it extends to minor offences arising from political protests?",
+        ],
+        "reasoning": {
+            "rejection_of_high_court_methodology": "The Supreme Court rejected the mechanical application of the disclosure rules by the High Court and District Court. It held that courts must look beyond the literal text to the legislative purpose, which is to prevent the criminalization of politics by targeting serious, not minor, offences.",
+            "application_of_precedent": "The Court distinguished the case from Krishnamoorthy vs. Sivakumar, noting that the Kerala Act had a specific provision (Sec 102(1)(ca)) making the circuitous interpretation of 'undue influence' unnecessary. It aligned with the principles of Association for Democratic Reforms and PUCL, emphasizing that the voter's right to know is focused on antecedents involving serious crimes, corruption, or moral turpitude.",
+            "duty_of_the_court": "The Court underscored its duty to adopt a purposive interpretation of election laws to avoid absurd outcomes. It held that voiding an election for non-disclosure of a minor offence related to a political protest would defeat the true object of the disclosure mandate, which is to ensure purity in public life by flagging candidates with serious criminal backgrounds.",
+            "evidence_based_determination": "The Court's decision was based on a careful examination of the nature of the offence for which the appellant was convicted. It was determined to be a minor, regulatory offence under the Kerala Police Act for disobeying a police officer's direction during a political dharna, not a substantive offence under the Indian Penal Code or other laws related to corruption or heinous crimes.",
+        },
+        "outcome": {
+            "decision": "The appeals were allowed, and the election of the appellant was upheld.",
+            "directions": [
+                "Set aside the impugned orders of the High Court of Kerala and the Additional District Judge.",
+                "Dismiss the Election Petition filed by the respondent.",
+            ],
+        },
+        "search_metadata": {
+            "summary": "The Supreme Court allowed the appeal of an elected Panchayat councilor whose election was declared void by lower courts for failing to disclose a past conviction. The conviction was for a minor offence under the Kerala Police Act, resulting from a political protest. The Court held that while the non-disclosure technically qualified as furnishing 'fake' information under Section 102(1)(ca) of the Kerala Panchayat Raj Act, 1994, the legislative intent behind such disclosure laws is to decriminalize politics by informing voters about serious or heinous criminal antecedents, not minor regulatory offences. Drawing a distinction between substantive crimes and minor offences arising from political activity, the Court adopted a purposive interpretation to conclude that voiding the election on this ground would be contrary to the object of the law. The lower court orders were set aside, and the election was upheld.",
+            "headnote": "The Supreme Court held that the mandatory disclosure of criminal antecedents by candidates in election nomination forms must be interpreted purposively. The core objective is to inform voters about involvement in serious or heinous offences relating to corruption or moral turpitude to prevent the criminalization of politics. A distinction must be drawn between such substantive offences and minor, regulatory offences arising from political activities like protests. The non-disclosure of a conviction for a minor, regulatory offence (e.g., under a Police Act for disobeying an order during a dharna) does not vitiate an election under Section 102(1)(ca) of the Kerala Panchayat Raj Act, 1994, as it falls outside the intended scope of the disclosure mandate.",
+            "keywords": [
+                "Election Law",
+                "Disclosure of Criminal Antecedents",
+                "Kerala Panchayat Raj Act 1994",
+                "Corrupt Practice",
+                "Fake Information",
+                "Section 102(1)(ca)",
+                "Section 52(1A)",
+                "Purposive Interpretation",
+                "Voter's Right to Know",
+                "Decriminalization of Politics",
+                "Regulatory Offence",
+                "Substantive Offence",
+                "Political Protest",
+                "Nomination Form",
+            ],
+            "legal_concepts": [
+                "Purity of Elections",
+                "Voter's Right to Information",
+                "Purposive Statutory Interpretation",
+                "Corrupt Practice in Election Law",
+                "Doctrine of Ultra Vires",
+                "Undue Influence",
+            ],
+            "acts_referred": [
+                "Kerala Panchayat Raj Act, 1994",
+                "Kerala Panchayat Raj (Conduct of Election) Rules, 1995",
+                "Kerala Police Act, 1961",
+                "Representation of the People Act, 1951",
+                "Indian Penal Code, 1860",
+                "Tamil Nadu Panchayats Act, 1994",
+                "Constitution of India",
+            ],
+        },
+    }
+]


### PR DESCRIPTION
## Summary
- build a Streamlit "Legal Research Copilot" chat experience that queries MongoDB and gracefully falls back to sample data
- add a MongoDB repository helper and bundled sample judgment to drive the UI when no database is reachable
- document setup steps and dependencies for running the app locally with configuration guidance

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cba038a1b08333b2393e035685873d